### PR TITLE
Holding Ctrl inverts mousedown behaviour

### DIFF
--- a/Source/LayeredForm.cs
+++ b/Source/LayeredForm.cs
@@ -433,11 +433,15 @@ namespace System.Windows.Forms {
             } else {
                base.WndProc(ref m);
             }
-         } else if(m_draggable && m.Msg == WM_LBUTTONDOWN) {
-            //Simulate title bar dragging for drag mode and only if the left mouse is down (to allow context menu to still fire)
-            SendMessage(Handle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+         } else if (m.Msg == WM_LBUTTONDOWN) {
+           var isCtrlDown = (Form.ModifierKeys == Keys.Control);
+           if ((m_draggable && !isCtrlDown) || (!m_draggable && isCtrlDown)) {
+             SendMessage(Handle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+           } else {
+             base.WndProc(ref m);
+           }
          } else {
-            base.WndProc(ref m);
+           base.WndProc(ref m);
          }
       }
    }

--- a/Source/LayeredForm.cs
+++ b/Source/LayeredForm.cs
@@ -436,6 +436,7 @@ namespace System.Windows.Forms {
          } else if (m.Msg == WM_LBUTTONDOWN) {
            var isCtrlDown = (Form.ModifierKeys == Keys.Control);
            if ((m_draggable && !isCtrlDown) || (!m_draggable && isCtrlDown)) {
+             //Simulate title bar dragging for drag mode and only if the left mouse is down (to allow context menu to still fire)
              SendMessage(Handle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
            } else {
              base.WndProc(ref m);


### PR DESCRIPTION
Small one to allow both types of dragging to happen in all situations with a key modifier.

If you don't have Draggable enabled and you hold Ctrl down while dragging, the window will drag.
If you do have Draggable enabled and you hold Ctrl down while dragging, the map will drag.